### PR TITLE
Refine crypto layout and add swing trading guidance

### DIFF
--- a/src/pages/crypto.html
+++ b/src/pages/crypto.html
@@ -16,8 +16,9 @@
         --surface: rgba(11, 27, 52, 0.92);
         --surface-elevated: rgba(14, 36, 70, 0.72);
         --surface-border: rgba(76, 157, 245, 0.35);
-        --text-strong: #f0f6ff;
+        --text-strong: #f1f7ff;
         --text-muted: #c1d0e9;
+        --text-subtle: rgba(193, 208, 233, 0.82);
     }
 
     /* Smooth scroll (si no está habilitado) */
@@ -25,20 +26,32 @@
         scroll-behavior: smooth;
     }
 
+    main h1,
     main h2,
     main h3,
     main h4 {
-        font-weight: 600;
-        letter-spacing: 0.02em;
-        margin-top: 1.75rem;
+        font-weight: 650;
+        letter-spacing: 0.01em;
+        color: var(--text-strong);
+    }
+
+    main h1 {
+        font-size: clamp(2.25rem, 1.2rem + 2vw, 3rem);
+        margin-bottom: 0.85rem;
     }
 
     main h2 {
+        font-size: clamp(1.85rem, 1.1rem + 1.4vw, 2.35rem);
         margin-bottom: 1rem;
     }
 
-    main h3,
+    main h3 {
+        font-size: clamp(1.45rem, 1rem + 0.8vw, 1.8rem);
+        margin-bottom: 0.8rem;
+    }
+
     main h4 {
+        font-size: clamp(1.18rem, 0.95rem + 0.5vw, 1.4rem);
         margin-bottom: 0.75rem;
     }
 
@@ -46,11 +59,12 @@
     .page-index {
         background: var(--surface);
         border: 1px solid var(--surface-border);
-        padding: 26px 28px;
-        border-radius: 20px;
-        margin: 0 auto 36px;
-        box-shadow: 0 22px 40px rgba(3, 11, 24, 0.55);
-        backdrop-filter: blur(6px);
+        padding: 32px 36px;
+        border-radius: 22px;
+        margin: 32px auto 52px;
+        box-shadow: 0 26px 44px rgba(3, 11, 24, 0.6);
+        backdrop-filter: blur(8px);
+        max-width: 960px;
     }
 
     .page-index h3 {
@@ -74,17 +88,17 @@
         padding: 0;
         margin: 0;
         display: grid;
-        gap: 12px 18px;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 18px 22px;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
     }
 
     .page-index li {
         margin: 0;
-        padding: 14px 16px;
-        border-radius: 14px;
+        padding: 16px 18px;
+        border-radius: 16px;
         background: var(--surface-elevated);
         border: 1px solid transparent;
-        box-shadow: 0 12px 24px rgba(5, 16, 33, 0.45);
+        box-shadow: 0 14px 26px rgba(5, 16, 33, 0.48);
         transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
     }
 
@@ -101,6 +115,7 @@
         display: inline-flex;
         align-items: center;
         gap: 8px;
+        line-height: 1.5;
     }
 
     .page-index a::before {
@@ -241,15 +256,147 @@
         display: flex;
         justify-content: center;
         align-items: center;
-        margin: 28px auto 22px;
+        margin: 28px auto;
     }
 
-    .section-divider {
-        border: none;
-        height: 1px;
-        width: min(420px, 80%);
-        background: linear-gradient(90deg, rgba(12, 38, 79, 0), rgba(12, 38, 79, 0.4), rgba(12, 38, 79, 0));
-        margin: 36px auto;
+    .content-shell {
+        width: 100%;
+        display: flex;
+        justify-content: center;
+    }
+
+    main {
+        width: min(1024px, 100%);
+        padding: 0 1.75rem 5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 3.5rem;
+    }
+
+    main section {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        color: var(--text-subtle);
+        line-height: 1.8;
+    }
+
+    main > section > ul {
+        display: grid;
+        gap: 0.85rem;
+        padding-left: 1.2rem;
+        margin: 0;
+        list-style: disc;
+    }
+
+    main ul ul {
+        display: grid;
+        gap: 0.6rem;
+        margin-top: 0.65rem;
+        padding-left: 1.1rem;
+        list-style: circle;
+    }
+
+    main li {
+        color: var(--text-subtle);
+        list-style-position: outside;
+        list-style-type: disc;
+    }
+
+    main ul ul > li {
+        list-style-type: circle;
+    }
+
+    main p {
+        margin: 0;
+        color: var(--text-subtle);
+    }
+
+    .mini-diagram {
+        font-family: "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        background: rgba(8, 20, 40, 0.8);
+        border: 1px solid var(--surface-border);
+        border-radius: 12px;
+        padding: 16px 18px;
+        line-height: 1.4;
+        color: var(--text-muted);
+        box-shadow: 0 18px 32px rgba(5, 16, 33, 0.55);
+        margin: 0;
+    }
+
+    .scenario-callout {
+        border-left: 3px solid var(--accent);
+        padding: 18px 20px;
+        border-radius: 12px;
+        background: rgba(19, 44, 82, 0.55);
+        display: grid;
+        gap: 0.85rem;
+    }
+
+    .scenario-callout strong {
+        color: var(--text-strong);
+    }
+
+    .numeric-example {
+        font-style: italic;
+        color: var(--text-muted);
+    }
+
+    .trade-checklist {
+        border: 1px solid var(--surface-border);
+        border-radius: 16px;
+        padding: 22px 24px;
+        background: rgba(10, 30, 58, 0.75);
+        box-shadow: 0 18px 32px rgba(5, 16, 33, 0.5);
+        display: grid;
+        gap: 1rem;
+    }
+
+    .trade-checklist h4 {
+        margin: 0;
+        color: var(--text-strong);
+        font-size: clamp(1.1rem, 0.95rem + 0.4vw, 1.35rem);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+    }
+
+    .trade-checklist ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.6rem;
+        list-style: disc;
+    }
+
+    .trade-checklist ul li {
+        list-style-type: disc;
+    }
+
+    #recommended-times ul,
+    #swing-trading-guide ul {
+        list-style: disc;
+    }
+
+    #recommended-times li,
+    #swing-trading-guide li {
+        padding-left: 0.15rem;
+        list-style-type: disc;
+    }
+
+    @media (max-width: 720px) {
+        .page-index {
+            padding: 28px 22px;
+            margin: 28px auto 44px;
+        }
+
+        main {
+            padding: 0 1.25rem 4rem;
+            gap: 3rem;
+        }
+
+        .scenario-callout {
+            padding: 16px;
+        }
     }
 
     footer {
@@ -396,110 +543,94 @@
         <li><a href="#rsi-bb-strategy">Estrategia: RSI + Bandas de Bollinger</a></li>
         <li><a href="#why-it-works">Por qué funciona</a></li>
         <li><a href="#example">Ejemplo práctico</a></li>
+        <li><a href="#recommended-times">Horarios recomendados</a></li>
+        <li><a href="#swing-trading-guide">Guía de swing trading</a></li>
       </ul>
     </nav>
-    <br>
 
     <!-- Inicio de contenido -->
-    <main>
-        <section id="intro">
-            <h1>Bitcoin</h1>
-            <p>Bitcoin es un activo escaso (oferta máxima de 21 millones) y descentralizado, considerado "oro digital". Eventos como los halvings, donde se reduce la recompensa por bloque, refuerzan esta escasez y suelen preceder subidas de precio.</p>
-            <p>Por ejemplo, quien invirtió $1,000 en BTC a comienzos de 2015 tendría ~$350,000 en 2024. Aunque el rendimiento pasado no garantiza resultados futuros, demuestra el potencial a largo plazo.</p>
-            
-            <div class="disclaimer-btn">
-                <button class="show-popup-btn" onclick="mostrarPopup()">Ver disclaimer</button>
-            </div>
-            <hr class="section-divider">
+    <div class="content-shell">
+        <main>
+            <section id="intro">
+                <h1>Bitcoin</h1>
+                <p>Bitcoin es un activo escaso (oferta máxima de 21 millones) y descentralizado, considerado "oro digital". Eventos como los halvings, donde se reduce la recompensa por bloque, refuerzan esta escasez y suelen preceder subidas de precio.</p>
+                <p>Por ejemplo, quien invirtió $1,000 en BTC a comienzos de 2015 tendría ~$350,000 en 2024. Aunque el rendimiento pasado no garantiza resultados futuros, demuestra el potencial a largo plazo.</p>
 
-        </section>
+                <div class="disclaimer-btn">
+                    <button class="show-popup-btn" onclick="mostrarPopup()">Ver disclaimer</button>
+                </div>
+                <hr>
+
+            </section>
 
         <!-- Tipos de inversion en Bitcoin -->
         <section id="investment-types">
             <h2>Tipos de inversión</h2>
             <ul>
                 <li><strong>HODLing estratégico (largo plazo):</strong> Comprar y mantener BTC durante años. Es simple y tiene potencial de grandes ganancias, pero requiere disciplina y seguridad.</li>
-                <br>
                 <li><strong>Trading activo:</strong>
                     <ul>
                         <li><strong>Scalping:</strong> Operaciones rápidas (minutos/horas). Requiere plataformas avanzadas y tiene alta exposición a errores.</li>
                         <li><strong>Swing trading:</strong> Basado en análisis técnico de días/semanas. Permite aprovechar tendencias, pero conlleva riesgos elevados.</li>
                     </ul>
                 </li>
-                <br>
                 <li><strong>Ingresos pasivos (yield):</strong> Prestar BTC para ganar intereses (~3–10% anual). Riesgo: quiebra de la plataforma.</li>
-                <br>
                 <li><strong>Cobertura con derivados:</strong> Uso de futuros u opciones para proteger tenencias ante caídas.</li>
             </ul>
-            <br><hr><br>
+            <hr>
         </section>
 
         <!-- Gestión de riesgos -->
         <section id="risk-management">
             <h2>Gestión de riesgos</h2>
             <p>Proteger tu capital es fundamental antes de buscar ganancias. Una gestión de riesgos adecuada puede marcar la diferencia entre un inversor exitoso y uno que sufre pérdidas significativas. Aquí te detallo algunas estrategias y conceptos clave:</p>
-            <br>
             <ul>
                 <li><strong>Tamaño de posición prudente:</strong> Arriesga solo 1–2% del portafolio por operación.
                     <p>Esta regla ayuda a evitar que una sola operación perdedora tenga un impacto devastador en tu capital total. Por ejemplo, si tienes un portafolio de $10,000, no deberías arriesgar más de $100-$200 en una sola operación.</p>
                 </li>
-                <br>
                 <li><strong>Órdenes de stop-loss y take-profit:</strong> Automatiza salidas para limitar pérdidas y asegurar ganancias.
-                    <ul><br>
+                    <ul>
                         <li><strong>Stop-Loss:</strong> Una orden para vender un activo cuando alcanza un precio específico, limitando la pérdida potencial.
                             <p>Imagina que compras BTC a $50,000. Estableces un stop-loss en $45,000. Si el precio cae a $45,000, tu posición se vende automáticamente, limitando tu pérdida a $5,000.</p>
                         </li>
-                        <br>
                         <li><strong>Take-Profit:</strong> Una orden para vender un activo cuando alcanza un precio específico, asegurando una ganancia.
                             <p>Siguiendo el ejemplo anterior, podrías establecer un take-profit en $60,000. Si el precio sube a $60,000, tu posición se vende automáticamente, asegurando una ganancia de $10,000.</p>
                         </li>
-                        <br>
                     </ul>
                 </li>
-                <br>
                 <li><strong>Leverage moderado:</strong> Si usas apalancamiento, mantén colateral suficiente y stops estrictos.
-                    <ul><br>
+                    <ul>
                         <li><strong>Apalancamiento:</strong> El uso de capital prestado para aumentar el potencial de retorno de una inversión.
                             <p>Un apalancamiento de 2x significa que con $1,000 de tu capital, puedes controlar $2,000 en BTC. Si el precio de BTC sube un 10%, tu ganancia sería del 20% ($200), pero si baja un 10%, tu pérdida también sería del 20% ($200).</p>
                         </li>
-                        <br>
                         <li><strong>Colateral:</strong> Activos ofrecidos como garantía para asegurar un préstamo.
                             <p>Al usar apalancamiento, el exchange requiere que mantengas un cierto nivel de colateral en tu cuenta. Si el precio se mueve en tu contra, tu colateral puede liquidarse para cubrir las pérdidas.</p>
                         </li>
-                        <br>
                     </ul>
                 </li>
-                <br>
                 <li><strong>Diversificación:</strong> Incluye activos no correlacionados para reducir riesgos.
-                    <ul><br>
+                    <ul>
                         <li><strong>Activos no correlacionados:</strong> Activos que no se mueven en la misma dirección al mismo tiempo.
                             <p>Por ejemplo, las acciones y los bonos a menudo tienen una correlación baja o negativa. Cuando las acciones bajan, los bonos pueden subir, y viceversa. Incluir ambos en tu portafolio reduce el riesgo general.</p>
                         </li>
-                        <br>
                         <li><strong>Ejemplos:</strong> Acciones, bonos, criptomonedas, materias primas, bienes raíces.</li>
-                        <br>
                     </ul>
                 </li>
                 <li><strong>Seguridad operativa:</strong> Usa 2FA y wallets confiables; para grandes montos, custodia en frío.
-                    <ul><br>
+                    <ul>
                         <li><strong>2FA (Autenticación de dos factores):</strong> Proceso de seguridad que requiere dos formas de identificación.
                             <p>Además de tu contraseña, el 2FA puede requerir un código enviado a tu teléfono o generado por una aplicación como Google Authenticator, añadiendo una capa extra de seguridad.</p>
                         </li>
-                        <br>
                         <li><strong>Wallets:</strong> Dispositivos o aplicaciones para almacenar criptomonedas.
                             <p>Es crucial elegir una wallet segura y confiable. Algunas opciones populares incluyen Ledger (hardware wallet), Trezor (hardware wallet) y Electrum (software wallet).</p>
                         </li>
-                        <br>
                         <li><strong>Custodia en frío:</strong> Almacenar criptomonedas fuera de línea para mayor seguridad.
                             <p>Esto implica guardar tus claves privadas en un dispositivo que no está conectado a Internet, como un hardware wallet o una cartera de papel, protegiéndolas de hackeos.</p>
                         </li>
-                        <br>
                     </ul>
                 </li>
             </ul>
-            <br>
             <hr>
-            <br>
         </section>
 
         <!-- Análisis técnico -->
@@ -507,14 +638,11 @@
             <h2>Análisis técnico</h2>
             <ul>
                 <li><strong>Patrones de velas japonesas:</strong> Formaciones como "hammer" o "doji" indican reversiones. Confirma con volumen.</li>
-                <br>
                 <li><strong>Indicadores técnicos:</strong> Herramientas como RSI y MACD ayudan a identificar sobrecompra, sobreventa y tendencias.</li>
-                <br>
                 <li><strong>Niveles de soporte y resistencia:</strong> Zonas donde el precio históricamente se detuvo. Usa Fibonacci para retrocesos.</li>
             </ul>
-            <br>
             <p><strong>Consejo:</strong> Combina varias herramientas para validar señales y gestiona siempre el riesgo.</p>
-            <br><hr><br>
+            <hr>
         </section>
 
         <!-- Análisis fundamental -->
@@ -522,12 +650,10 @@
             <h2>Análisis fundamental</h2>
             <ul>
                 <li><strong>Métricas on-chain:</strong> Datos como el Puell Multiple o SOPR muestran la salud de la red y ciclos de mercado.</li>
-                <br>
                 <li><strong>Eventos macro:</strong> Políticas monetarias, inflación y regulación influyen en el precio de Bitcoin.</li>
-                <br>
                 <li><strong>Minería:</strong> Cambios en dificultad y hashrate reflejan la estabilidad de la red.</li>
             </ul>
-            <br><hr><br>
+            <hr>
         </section>
 
         <!-- Futuros y derivados -->
@@ -535,12 +661,10 @@
             <h2>Futuros y derivados</h2>
             <ul>
                 <li><strong>Futuros perpetuos:</strong> Contratos sin vencimiento con settlement diario. Alta flexibilidad, pero alto riesgo.</li>
-                <br>
                 <li><strong>Opciones:</strong> Contratos call/put para especular o proteger. Estrategias comunes: straddle, iron condor.</li>
             </ul>
-            <br>
             <p><strong>Nota:</strong> Los derivados amplifican tanto ganancias como pérdidas. Requieren estrategias disciplinadas.</p>
-            <br><hr><br>
+            <hr>
         </section>
 
         <!-- Estrategia RSI + Bandas de Bollinger (para BTC Spot) -->
@@ -560,19 +684,24 @@
         
           <h3>Explicación del RSI</h3>
           <p>
-            El RSI (Relative Strength Index) mide fuerza y momentum en una escala de 0 a 100.
-            Niveles útiles: <strong>30</strong> (sobreventa) y <strong>70</strong> (sobrecompra).
-            En tu configuración verás la <em>línea morada</em> como el valor del RSI y una <em>línea amarilla</em> si añades una media del RSI.
+            El RSI (Relative Strength Index) mide fuerza y momentum en una escala de 0 a 100. Los umbrales comunes son <strong>30</strong> (sobreventa) y <strong>70</strong> (sobrecompra), y muchos traders añaden una media móvil del RSI para suavizar las señales.
+            En tu gráfico, configura el RSI con longitud 14 y activa una media simple para evaluar cruces.
           </p>
 
-          <h4>RSI — escenarios comunes y qué significan</h4>
-          <ul>
-            <li><strong>RSI cerca de 50:</strong> mercado en equilibrio. Espera confirmación antes de entrar con fuerza.</li>
-            <li><strong>RSI por debajo de 30:</strong> posible rebote técnico; busca velas de reversión o volumen que confirme.</li>
-            <li><strong>RSI por encima de 70:</strong> riesgo de corrección; considera asegurar ganancias o ajustar stops.</li>
-            <li><strong>Cruce del RSI con su media:</strong> cruce al alza sugiere mejora de momentum; a la baja indica debilidad.</li>
-            <li><strong>Divergencias:</strong> si el precio marca nuevos mínimos y el RSI no (divergencia alcista) puede anticipar un giro; si marca nuevos máximos y el RSI cae (divergencia bajista) alerta de posibles correcciones.</li>
-          </ul>
+          <div class="scenario-callout">
+            <h4>RSI — escenarios prácticos y acción recomendada</h4>
+            <ul>
+              <li><strong>RSI ≈ 50 (mercado neutro):</strong> evita entradas agresivas; espera ruptura de rango, vela impulsiva o confirmación de volumen antes de operar.</li>
+              <li><strong>RSI &lt; 30 + vela de reversal:</strong> abre entrada parcial y ubica el stop-loss bajo el mínimo reciente; escala solo si el rebote continúa.</li>
+              <li><strong>RSI &gt; 70 + toque de banda superior:</strong> toma ganancias parciales o ajusta stops; el momentum suele relajarse tras este combo.</li>
+              <li><strong>Cruce del RSI sobre su media lenta:</strong> valida el momentum alcista; úsalo como filtro adicional para sostener posiciones o descartar rupturas débiles.</li>
+              <li><strong>Divergencias (alto valor predictivo):</strong> cuando el precio hace un nuevo mínimo pero el RSI sube (divergencia alcista) o el precio marca un máximo y el RSI desciende (divergencia bajista), prepara entradas inversas con confirmación de vela.</li>
+            </ul>
+            <div class="mini-diagram" aria-hidden="true">
+Precio:  \__/‾‾‾\
+RSI:    \__/__  \
+            </div>
+          </div>
 
           <h4>Ajustes recomendados para RSI</h4>
           <ul>
@@ -592,14 +721,16 @@
             Las bandas se ensanchan con alta volatilidad y se estrechan con baja volatilidad (compresión).
           </p>
 
-          <h4>Bandas de Bollinger — escenarios comunes y acciones</h4>
-          <ul>
-            <li><strong>Precio sobre la SMA 20:</strong> contexto lateral; espera ruptura o patrón claro antes de posicionarte.</li>
-            <li><strong>Precio en banda inferior + RSI bajo:</strong> posible rebote. Opta por entradas parciales y stops ajustados.</li>
-            <li><strong>Precio en banda superior + RSI alto:</strong> terreno para tomar ganancias parciales o ajustar stops.</li>
-            <li><strong>Bandas en compresión:</strong> indican volatilidad contenida; prepara la operativa para la ruptura con confirmación de volumen.</li>
-            <li><strong>Bandas en expansión:</strong> muestran volatilidad creciente; confirma con volumen para validar el movimiento y evitar rupturas falsas.</li>
-          </ul>
+          <div class="scenario-callout">
+            <h4>Bandas de Bollinger — escenarios prácticos y acción</h4>
+            <ul>
+              <li><strong>Precio en la SMA 20 (línea central):</strong> señala consolidación; espera ruptura con volumen o patrón de velas antes de abrir posición.</li>
+              <li><strong>Bandas estrechas (compresión):</strong> prepara alertas y define niveles de entrada/stop para operar la ruptura acompañada de volumen.</li>
+              <li><strong>Bandas en expansión + ruptura:</strong> si el volumen confirma, deja correr el trade usando trailing stop para capturar la tendencia.</li>
+              <li><strong>Toque de banda inferior + RSI bajo:</strong> busca rebotes medidos; entra parcial con stop bajo la banda y objetivo en la SMA 20 o banda superior.</li>
+            </ul>
+            <p class="numeric-example">Ej.: BTC 4H: RSI 28 + martillo en banda inferior = entrada parcial; stop 1.5% por debajo de la vela; TP en banda superior.</p>
+          </div>
 
           <h4>Ajustes recomendados para Bandas de Bollinger</h4>
           <ul>
@@ -666,33 +797,148 @@
         </section>
 
 
+        <section id="recommended-times">
+          <h2>Horarios recomendados para revisar (CST, UTC−6)</h2>
+          <p>
+            Aquí tienes una guía práctica para revisar tus gráficos en timeframe 1H sin estar pegado a la pantalla.
+            Revisa justo después del cierre de la vela horaria (ej. 01:05) para evitar señales parciales mientras la vela se forma.
+          </p>
+
+          <h3>Frecuencia sugerida</h3>
+          <ul>
+            <li>Revisiones diarias: <strong>3–4 veces al día</strong>. Duración: 5–15 minutos por chequeo.</li>
+            <li>Usa alertas automáticas (RSI cruces, toque de Bandas de Bollinger, rupturas) para reducir la supervisión continua.</li>
+          </ul>
+
+          <h3>Horarios concretos (CST, UTC−6) y por qué</h3>
+          <ul>
+            <li>
+              <strong>18:00–20:00 CST</strong> — Sesión asiática / pre-actividad americana<br>
+              Por qué: empiezan a moverse los mercados asiáticos; aparecen desequilibrios nocturnos y setups tempranos.
+            </li>
+            <li>
+              <strong>01:00–03:00 CST</strong> — Apertura europea (media)<br>
+              Por qué: flujo europeo que suele aumentar la volatilidad y confirmar rupturas iniciadas en Asia.
+            </li>
+            <li>
+              <strong>08:00–10:00 CST</strong> — Apertura y pico de la sesión americana<br>
+              Por qué: ventana con mayor volumen para BTC; señales confirmadas aquí tienen más peso.
+            </li>
+            <li>
+              <strong>13:00–15:00 CST</strong> — Cierre de la jornada americana / confirmación diaria<br>
+              Por qué: cierre de sesión en USA y reajuste de posiciones globales; buen momento para decidir dejar posiciones correr o asegurar ganancias.
+            </li>
+          </ul>
+
+          <h3>Qué mirar en cada chequeo (checklist rápido)</h3>
+          <ul>
+            <li>Cierre de la vela 1H: ¿confirmó la señal (RSI + Bandas) tras el cierre?</li>
+            <li>Volumen: ¿la vela de confirmación trae volumen mayor al promedio reciente?</li>
+            <li>Posición del precio respecto a la SMA20 (línea central de Bollinger).</li>
+            <li>Soporte / resistencia cercano: ¿estoy entrando sobre un soporte válido o en resistencia fuerte?</li>
+            <li>Gestión: mover stop a breakeven si se alcanzó tu objetivo intermedio; considerar salida parcial si RSI &gt; 70.</li>
+            <li>Noticias programadas: si hay evento macro, reducir exposición o evitar abrir nuevas posiciones.</li>
+          </ul>
+
+          <h3>Reglas prácticas para no sobre-operar</h3>
+          <ul>
+            <li>No entrar solo por una vela incompleta; esperar cierre horario.</li>
+            <li>Si recibes una alerta fuera de tus ventanas, esperar el siguiente cierre de 1H para confirmar.</li>
+            <li>Máximo recomendado mientras aprendes: 1–2 operaciones simultáneas en spot.</li>
+          </ul>
+
+          <h3>Plantilla de horario compacta (ejemplo)</h3>
+          <ul>
+            <li>Opción 3 checks: <strong>20:05, 01:05, 09:05 CST</strong>.</li>
+            <li>Opción 4 checks: <strong>20:05, 01:05, 09:05, 14:05 CST</strong>.</li>
+          </ul>
+        </section>
+
+
+        <section id="swing-trading-guide">
+          <h2>Swing trading — guía práctica</h2>
+          <p>
+            El swing trading busca capturar movimientos intermedios (desde horas hasta semanas). No es scalping ni inversión a muy largo plazo.
+            Se basa en identificar tendencias, rebotes y rupturas, gestionando riesgo con stops y tamaño de posición adecuados.
+          </p>
+
+          <h3>Características principales</h3>
+          <ul>
+            <li>Horizonte típico: varias horas hasta semanas.</li>
+            <li>Timeframes usados comúnmente: <strong>1H, 4H, diario</strong>. Tú usarás 1H para entradas y 4H para confirmaciones mayores.</li>
+            <li>Se apoya en análisis técnico: soportes/resistencias, RSI, Bandas de Bollinger, volumen.</li>
+            <li>Gestión de riesgo: stops claros, tamaño de posición controlado (1–2% del portafolio por operación).</li>
+          </ul>
+
+          <h3>Ventajas y desventajas</h3>
+          <ul>
+            <li><strong>Ventajas:</strong> más oportunidades que el swing a diario; permite sacar provecho de movimientos significativos sin vigilar todo el día.</li>
+            <li><strong>Desventajas:</strong> requiere disciplina con stops; movimientos grandes pueden generar mayor drawdown temporal.</li>
+          </ul>
+
+          <h3>Proceso simplificado de una operación swing (pasos)</h3>
+          <ol>
+            <li>Identificar setup: RSI y Bandas de Bollinger muestran condición (ej. RSI &lt; 30 + toque banda inferior).</li>
+            <li>Confirmar: espera cierre de vela 1H; revisa volumen y estructura (soporte/resistencia).</li>
+            <li>Calcular tamaño de posición: riesgo monetario = 1% del portafolio; distancia al stop → determinar tamaño.</li>
+            <li>Abrir posición parcial (opcional): por ejemplo 50% del tamaño planeado para validar movimiento.</li>
+            <li>Gestionar: mover stop a breakeven al alcanzar objetivo parcial; tomar ganancias parciales cuando RSI ≥ 60–70 o precio en banda superior.</li>
+            <li>Salir o trailing: si ruptura con volumen, usar trailing stop; si señal se invalida (RSI cruza en sentido contrario), cerrar parcialmente o totalmente.</li>
+          </ol>
+
+          <h3>Reglas de gestión de riesgo (esenciales)</h3>
+          <ul>
+            <li>Riesgo por operación: ≤ 1–2% del portafolio.</li>
+            <li>Stop-loss: colocarlo según soporte técnico o por debajo de la banda inferior si entras en rebote.</li>
+            <li>Take-profit: objetivo inicial en banda superior o cuando RSI ≈ 70; considerar salida parcial y trailing stop.</li>
+            <li>Registro: llevar un diario con marco temporal, razón de entrada, stop, take, resultado y lección.</li>
+          </ul>
+
+          <h3>Ejemplo práctico breve (resumen)</h3>
+          <p>
+            BTC en 1H: RSI baja a 28 y la vela toca la banda inferior. Esperas el cierre de la vela 1H; aparece una vela martillo con volumen mayor.
+            Entras parcial, pones stop por debajo del mínimo reciente (o banda inferior) y TP inicial en banda superior. Si la subida tiene volumen y rompe la banda superior, aplicas trailing stop.
+          </p>
+
+          <h3>Checklist rápido antes de abrir (para pegar como card)</h3>
+          <div class="trade-checklist">
+            <h4>Checklist antes de operar</h4>
+            <ul>
+              <li>RSI <strong>&lt; 30</strong> o señal clara según regla.</li>
+              <li>Cierre de vela 1H confirma la señal.</li>
+              <li>Volumen acompaña la confirmación.</li>
+              <li>Soporte/resistencia verificados.</li>
+              <li>Stop-loss y tamaño de posición definidos (≤ 2% riesgo).</li>
+            </ul>
+          </div>
+        </section>
+
+
         <!-- Estrategias avanzadas -->
         <section id="advanced-strategies">
             <h2>Estrategias avanzadas</h2>
-            <br>
             <ul>
                 <li><strong>Comprar en capitulación:</strong> Usar indicadores como Hash Ribbons para identificar oportunidades en pánico.</li>
                 <li><strong>Arbitraje entre exchanges:</strong> Aprovechar diferencias de precios en mercados.</li>
                 <li><strong>Seguimiento de rupturas:</strong> Detectar rompimientos de resistencias con alto volumen para entrar en tendencia.</li>
             </ul>
-            <br><hr><br>
+            <hr>
         </section>
 
         <!-- Recursos adicionales -->
         <section id="resources">
             <h2>Recursos adicionales</h2>
-            <br>
             <ul>
                 <li><strong>Documentación:</strong> <a href="https://www.investopedia.com/bitcoin-halving-4843769" target="_blank">Bitcoin Halving (Investopedia)</a></li>
                 <li><strong>Guías:</strong> <a href="https://coinbureau.com/guides/risk-management-strategies-crypto-trading/" target="_blank">Estrategias de gestión de riesgos (Coin Bureau)</a></li>
                 <li><strong>Reportes:</strong> <a href="https://bitcoinmagazine.com/markets/exploring-six-on-chain-indicators-to-understand-the-bitcoin-market-cycle" target="_blank">Indicadores on-chain (Bitcoin Magazine)</a></li>
             </ul>
-            <br>
             <p>Consulta estas fuentes para mejorar tu conocimiento y estrategias.</p>
-            <br><hr><br>
+            <hr>
         </section>
 
     </main>
+    </div>
 
     <footer>
         <p>©2025 DesvoSoft</p>


### PR DESCRIPTION
## Summary
- restore the default themed separators by removing the custom crypto page `<hr>` override
- add recommended review schedules, checklists, and anti over-trading rules for 1H monitoring
- expand the guide with a swing trading primer, risk rules, and a styled pre-trade checklist card

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_69043fb772588327a2d8397946006265